### PR TITLE
Enable MediaFoundation encoders

### DIFF
--- a/build/ffmpeg_options.txt
+++ b/build/ffmpeg_options.txt
@@ -14,6 +14,7 @@
 --enable-zlib
 --enable-ffnvcodec
 --enable-nvdec
+--enable-mediafoundation
 
 # Common options
 --enable-libx264


### PR DESCRIPTION
Media Foundation provides vendor-independent hardware accelerated encoding on Windows.